### PR TITLE
Match card background in generated pdf

### DIFF
--- a/cursoMapear.html
+++ b/cursoMapear.html
@@ -1040,6 +1040,8 @@
             { x: margin, y: margin + cellH + gap, w: cellW, h: cellH },
             { x: margin + cellW + gap, y: margin + cellH + gap, w: cellW, h: cellH }
           ];
+          const headerText = 'BARALHO PEDAGÓGICO MAPEAR';
+          const headerH = 10; // espaço reservado no topo da carta (mm)
 
           for (let i = 0; i < deckCards.length; i++) {
             if (i > 0 && i % 4 === 0) pdf.addPage();
@@ -1049,7 +1051,12 @@
             const cell = cells[i % 4];
             pdf.setFillColor(11, 16, 32);
             pdf.rect(cell.x, cell.y, cell.w, cell.h, 'F');
-            const rect = fitInsideCell(pdf, dataUrl, cell);
+            pdf.setTextColor(255, 255, 255);
+            pdf.setFont('helvetica', 'bold');
+            pdf.setFontSize(10);
+            pdf.text(headerText, cell.x + (cell.w / 2), cell.y + 6, { align: 'center' });
+            const imageCell = { x: cell.x, y: cell.y + headerH, w: cell.w, h: cell.h - headerH };
+            const rect = fitInsideCell(pdf, dataUrl, imageCell);
             pdf.addImage(dataUrl, 'PNG', rect.x, rect.y, rect.w, rect.h);
           }
 

--- a/cursoMapear.html
+++ b/cursoMapear.html
@@ -1002,15 +1002,15 @@
       }
 
       async function elementToDataUrl(el){
-        const baseCanvas = await html2canvas(el, { backgroundColor: '#ffffff', scale: 3, useCORS: true, allowTaint: true });
-        // Pós-processamento para escurecer e aumentar contraste/saturação
-        const adjusted = document.createElement('canvas');
-        adjusted.width = baseCanvas.width;
-        adjusted.height = baseCanvas.height;
-        const ctx = adjusted.getContext('2d');
-        ctx.filter = 'contrast(1.3) brightness(0.9) saturate(1.15)';
-        ctx.drawImage(baseCanvas, 0, 0);
-        return adjusted.toDataURL('image/png');
+        const rootStyles = getComputedStyle(document.documentElement);
+        const bgVar = (rootStyles.getPropertyValue('--bg') || '#0b1020').trim() || '#0b1020';
+        const baseCanvas = await html2canvas(el, {
+          backgroundColor: bgVar,
+          scale: 3,
+          useCORS: true,
+          allowTaint: true
+        });
+        return baseCanvas.toDataURL('image/png');
       }
 
       async function generateDeckPdf(){
@@ -1047,6 +1047,8 @@
             await new Promise(r => requestAnimationFrame(r));
             const dataUrl = await elementToDataUrl(card);
             const cell = cells[i % 4];
+            pdf.setFillColor(11, 16, 32);
+            pdf.rect(cell.x, cell.y, cell.w, cell.h, 'F');
             const rect = fitInsideCell(pdf, dataUrl, cell);
             pdf.addImage(dataUrl, 'PNG', rect.x, rect.y, rect.w, rect.h);
           }


### PR DESCRIPTION
Render playing cards in PDF with the correct black background, matching the website's appearance.

---
<a href="https://cursor.com/background-agent?bcId=bc-7f31c8a0-6a73-4e0f-bfbe-676b33890682">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7f31c8a0-6a73-4e0f-bfbe-676b33890682">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

