### PR TITLE
Arrange course and game buttons below logo

### DIFF
--- a/conteudo.html
+++ b/conteudo.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Conteúdo — Arcabouço Pedagógico MAPEAR</title>
+  <link rel="icon" type="image/png" href="/MAPEARFavicon.png">
+  <link rel="stylesheet" href="./styles.css">
+</head>
+<body>
+  <header class="app-header">
+    <div class="brand">
+      <span class="brand-title">Arcabouço Pedagógico MAPEAR</span>
+      <span class="brand-subtitle">Pensamento Computacional com Consciência</span>
+    </div>
+    <nav class="main-nav">
+      <a class="btn ghost" href="./FichasRubricasMAPEAR.pdf" download>Baixar Rubricas (PDF)</a>
+      <a class="btn ghost" href="index.html#intro">Início</a>
+      <a class="btn ghost" href="conteudo.html">Conteúdo</a>
+      <a class="btn ghost" href="cursoMapear.html">Curso</a>
+      <a class="btn ghost" href="mapear.html#/">Jogos</a>
+    </nav>
+  </header>
+
+  <main class="app-container">
+    <section id="fases" class="card" style="margin-top:16px;">
+      <h2>Fases da Proposta MAPEAR</h2>
+      <p class="muted">A proposta organiza-se em seis fases formativas interdependentes, concebidas para criar um ciclo contínuo de aprendizagem:</p>
+      <ol>
+        <li><h3><strong>Motivar:</strong></h3> Estimula o engajamento dos estudantes por meio de desafios contextualizados, conectando problemas reais ao uso do PC. Objetiva despertar curiosidade, interesse e protagonismo.</li>
+        <li><h3><strong>Apresentar Conceitos:</strong></h3> Introdução estruturada e acessível dos fundamentos do PC — decomposição, abstração, reconhecimento de padrões e raciocínio algorítmico — utilizando exemplos concretos e experiências pedagógicas alinhadas à realidade dos participantes.</li>
+        <li><h3><strong>Planejar e Prototipar:</strong></h3> Professores e alunos planejam atividades e projetos, criando mapas conceituais, fluxogramas e pseudocódigos. A fase integra soluções digitais e desplugadas, considerando o contexto e a disponibilidade de recursos.</li>
+        <li><h3><strong>Experimentar com Tecnologia:</strong></h3> Aplicação prática dos conceitos utilizando plataformas como Scratch, Code.org, Tinkercad Circuits, MakeCode, simuladores Arduino, kits físicos (Arduino, Micro:bit, LEGO Education) e os Jogos MAPEAR. Essa etapa valoriza aprendizagem ativa por meio da experimentação e construção colaborativa.</li>
+        <li><h3><strong>Analisar e Ajustar:</strong></h3> Reflexão crítica sobre os resultados obtidos. Identificação de acertos, desafios e estratégias de melhoria. Incentiva postura investigativa e capacidade de adaptação frente a problemas pedagógicos.</li>
+        <li><h3><strong>Refletir e Compartilhar:</strong></h3> Sistematização das aprendizagens e socialização das experiências com a comunidade escolar, via feiras, portfólios digitais ou plataformas colaborativas. Promove redes de colaboração e consolida práticas inovadoras.</li>
+      </ol>
+    </section>
+
+    <section id="recursos" class="card" style="margin-top:16px;">
+      <h2>Recursos Integrados do Arcabouço Pedagógico MAPEAR</h2>
+      <h3>Jogos MAPEAR</h3>
+      <ul>
+        <li>Feedback em tempo real para aprendizagem autônoma;</li>
+        <li>Monitoramento do progresso através de relatórios;</li>
+        <li>Atividades que integram conceitos de PC e RE de forma lúdica.</li>
+      </ul>
+      <h3>Curso de Formação MAPEAR (presencial, híbrido ou EAD)</h3>
+      <ul>
+        <li>Fundamentos do PC na educação básica;</li>
+        <li>Ferramentas digitais e atividades desplugadas;</li>
+        <li>Planejamento de projetos escolares com mediação ativa e RE;</li>
+        <li>Estratégias de avaliação de competências computacionais;</li>
+        <li>Compartilhamento de experiências e banco de práticas.</li>
+      </ul>
+      <h3>Kits Didáticos e Atividades Guiadas</h3>
+      <ul>
+        <li>Kits analógicos: baralhos pedagógicos, mapas de algoritmos, desafios em papel;</li>
+        <li>Kits digitais: simuladores, aplicativos e plataformas de programação;</li>
+        <li>Roteiros passo a passo para projetos interdisciplinares;</li>
+        <li>Rubricas de avaliação para monitoramento de competências.</li>
+      </ul>
+    </section>
+
+    <section id="diferenciais" class="card" style="margin-top:16px;">
+      <h2>Diferenciais do Arcabouço Pedagógico MAPEAR</h2>
+      <ul>
+        <li><strong>Flexibilidade:</strong> aplicável com ou sem tecnologia digital;</li>
+        <li><strong>Interdisciplinaridade:</strong> integração do PC com conteúdos curriculares e problemas reais;</li>
+        <li><strong>Protagonismo:</strong> incentiva autoria e autonomia de alunos e professores;</li>
+        <li><strong>Ciclos ativos</strong> de teoria, prática e reflexão;</li>
+        <li><strong>Formação contínua</strong> com trilhas gamificadas e microcertificações;</li>
+        <li><strong>Colaboração:</strong> socialização de práticas e fortalecimento de redes escolares.</li>
+      </ul>
+    </section>
+
+    <section id="steam" class="card" style="margin-top:16px;">
+      <h2>Integração com Metodologias Ativas e STEAM</h2>
+      <ul>
+        <li>Solução de problemas reais e contextualizados;</li>
+        <li>Aprendizagem interdisciplinar, conectando Ciências, Tecnologia, Engenharia, Artes e Matemática;</li>
+        <li>Desenvolvimento de habilidades cognitivas e socioemocionais;</li>
+        <li>Engajamento ativo e construção colaborativa do conhecimento.</li>
+      </ul>
+    </section>
+
+    <section id="resultados" class="card" style="margin-top:16px;">
+      <h2>Resultados Esperados</h2>
+      <ol>
+        <li><strong>Aprendizagem dos Estudantes:</strong> Engajamento, pensamento crítico, criatividade e competências em PC.</li>
+        <li><strong>Competências Docentes:</strong> Habilidade de integrar PC e RE em práticas pedagógicas alinhadas à BNCC.</li>
+        <li><strong>Repertório Pedagógico:</strong> Diversificação de estratégias de ensino com metodologias ativas, gamificação e recursos tecnológicos.</li>
+        <li><strong>Comunidade de Prática:</strong> Criação de redes colaborativas de alunos e professores que compartilham experiências e aprimoram continuamente a metodologia.</li>
+      </ol>
+    </section>
+
+    <section id="finais" class="card" style="margin-top:16px;">
+      <h2>Considerações Finais</h2>
+      <p>
+        O Arcabouço Pedagógico MAPEAR constitui uma abordagem inovadora que conecta teoria, prática, reflexão e tecnologia, favorecendo o desenvolvimento de competências de PC, habilidades socioemocionais e aprendizagem significativa. Sua flexibilidade, interdisciplinaridade e foco em protagonismo tornam-na adequada para contextos diversos, desde escolas básicas até programas de formação docente.
+      </p>
+      <p>
+        O ensino com o Arcabouço Pedagógico MAPEAR permite aos alunos e professores explorar o Pensamento Computacional de forma ativa e reflexiva, promovendo a construção de conhecimento contextualizado, colaborativo e interdisciplinar, essencial para a educação do século XXI.
+      </p>
+    </section>
+  </main>
+
+  <footer class="app-footer">
+    <small>Arcabouço Pedagógico MAPEAR — Aprendizagem ativa, reflexiva e colaborativa.</small>
+  </footer>
+</body>
+</html>

--- a/cursoMapear.html
+++ b/cursoMapear.html
@@ -40,7 +40,7 @@
     .wrap { max-width: 1100px; margin: 0 auto; padding: calc(28px + var(--hero-offset)) 28px 28px }
     header.hero {
       border-radius: var(--radius-xl);
-      background: linear-gradient(135deg, rgba(124,156,255,.14), rgba(34,197,94,.10));
+      background: #111827;
       padding: 36px;
       box-shadow: var(--shadow-2);
       position: fixed;
@@ -104,7 +104,7 @@
     /* Compensa cabeçalho fixo nas âncoras */
     section[id], article[id], h2[id], h3[id] { scroll-margin-top: var(--hero-offset) }
     .nav {
-      position: sticky; top: calc(var(--hero-offset) + 12px); background: rgba(12,18,40,.7); backdrop-filter: blur(6px);
+      position: sticky; top: calc(var(--hero-offset) + 12px); background: #111827; backdrop-filter: none;
       border:1px solid rgba(255,255,255,.08); border-radius: 14px; padding: 12px; box-shadow: var(--shadow-1)
     }
     .nav a { display:block; padding: 8px 10px; border-radius: 10px }
@@ -140,6 +140,9 @@
     <header class="hero" id="topo" aria-labelledby="titulo">
       <nav class="quick-nav" role="navigation" aria-label="Navegação rápida">
         <a class="btn ghost" href="#topo">Topo</a>
+        <a class="btn ghost" href="index.html#intro">Início</a>
+        <a class="btn ghost" href="conteudo.html">Conteúdo</a>
+        <a class="btn ghost" href="mapear.html#/">Jogos</a>
         <a class="btn ghost" href="#programa">Programa</a>
         <a class="btn ghost" href="#mod1">Módulo 1</a>
         <a class="btn ghost" href="#mod2">Módulo 2</a>

--- a/index.html
+++ b/index.html
@@ -51,8 +51,8 @@
         <img alt="Logo da Metodologia MAPEAR" src="https://carolsoko.github.io/mapear/MAPEAR.png">
       </div>
       <div class="hero-actions">
-        <a class="button cta secondary" href="cursoMapear.html" target="_blank" rel="noopener">Abrir Curso MAPEAR</a>
-        <a class="button cta primary" href="mapear.html#/" target="_blank" rel="noopener">Abrir Jogos MAPEAR</a>
+        <a class="button cta secondary" href="cursoMapear.html">Abrir Curso MAPEAR</a>
+        <a class="button cta primary" href="mapear.html#/">Abrir Jogos MAPEAR</a>
       </div>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -27,14 +27,9 @@
     <nav class="main-nav">
       <a class="btn ghost" href="./FichasRubricasMAPEAR.pdf" download>Baixar Rubricas (PDF)</a>
       <a class="btn ghost" href="#intro">Introdução</a>
-      <a class="btn ghost" href="#fases">Fases</a>
-      <a class="btn ghost" href="#recursos">Recursos</a>
-      <a class="btn ghost" href="#diferenciais">Diferenciais</a>
-      <a class="btn ghost" href="#steam">Integração STEAM</a>
-      <a class="btn ghost" href="#resultados">Resultados</a>
-      <a class="btn ghost" href="#finais">Considerações</a>
-      <a class="btn ghost" href="#curso">Curso</a>
-      <a class="btn ghost" href="#jogos">Jogos</a>
+      <a class="btn ghost" href="conteudo.html">Conteúdo</a>
+      <a class="btn ghost" href="cursoMapear.html">Curso</a>
+      <a class="btn ghost" href="mapear.html#/">Jogos</a>
     </nav>
   </header>
 
@@ -54,98 +49,6 @@
         <a class="button cta secondary" href="cursoMapear.html">Abrir Curso MAPEAR</a>
         <a class="button cta primary" href="mapear.html#/">Abrir Jogos MAPEAR</a>
       </div>
-    </section>
-
-    <section id="fases" class="card" style="margin-top:16px;">
-      <h2>Fases da Proposta MAPEAR</h2>
-      <p class="muted">A proposta organiza-se em seis fases formativas interdependentes, concebidas para criar um ciclo contínuo de aprendizagem:</p>
-      <ol>
-        <li><h3><strong>Motivar:</strong></h3> Estimula o engajamento dos estudantes por meio de desafios contextualizados, conectando problemas reais ao uso do PC. Objetiva despertar curiosidade, interesse e protagonismo.</li>
-        <li><h3><strong>Apresentar Conceitos:</strong></h3> Introdução estruturada e acessível dos fundamentos do PC — decomposição, abstração, reconhecimento de padrões e raciocínio algorítmico — utilizando exemplos concretos e experiências pedagógicas alinhadas à realidade dos participantes.</li>
-        <li><h3><strong>Planejar e Prototipar:</strong></h3> Professores e alunos planejam atividades e projetos, criando mapas conceituais, fluxogramas e pseudocódigos. A fase integra soluções digitais e desplugadas, considerando o contexto e a disponibilidade de recursos.</li>
-        <li><h3><strong>Experimentar com Tecnologia:</strong></h3> Aplicação prática dos conceitos utilizando plataformas como Scratch, Code.org, Tinkercad Circuits, MakeCode, simuladores Arduino, kits físicos (Arduino, Micro:bit, LEGO Education) e os Jogos MAPEAR. Essa etapa valoriza aprendizagem ativa por meio da experimentação e construção colaborativa.</li>
-        <li><h3><strong>Analisar e Ajustar:</strong></h3> Reflexão crítica sobre os resultados obtidos. Identificação de acertos, desafios e estratégias de melhoria. Incentiva postura investigativa e capacidade de adaptação frente a problemas pedagógicos.</li>
-        <li><h3><strong>Refletir e Compartilhar:</strong></h3> Sistematização das aprendizagens e socialização das experiências com a comunidade escolar, via feiras, portfólios digitais ou plataformas colaborativas. Promove redes de colaboração e consolida práticas inovadoras.</li>
-      </ol>
-    </section>
-
-    <section id="recursos" class="card" style="margin-top:16px;">
-      <h2>Recursos Integrados do Arcabouço Pedagógico MAPEAR</h2>
-      <h3>Jogos MAPEAR</h3>
-      <ul>
-        <li>Feedback em tempo real para aprendizagem autônoma;</li>
-        <li>Monitoramento do progresso através de relatórios;</li>
-        <li>Atividades que integram conceitos de PC e RE de forma lúdica.</li>
-      </ul>
-      <h3>Curso de Formação MAPEAR (presencial, híbrido ou EAD)</h3>
-      <ul>
-        <li>Fundamentos do PC na educação básica;</li>
-        <li>Ferramentas digitais e atividades desplugadas;</li>
-        <li>Planejamento de projetos escolares com mediação ativa e RE;</li>
-        <li>Estratégias de avaliação de competências computacionais;</li>
-        <li>Compartilhamento de experiências e banco de práticas.</li>
-      </ul>
-      <h3>Kits Didáticos e Atividades Guiadas</h3>
-      <ul>
-        <li>Kits analógicos: baralhos pedagógicos, mapas de algoritmos, desafios em papel;</li>
-        <li>Kits digitais: simuladores, aplicativos e plataformas de programação;</li>
-        <li>Roteiros passo a passo para projetos interdisciplinares;</li>
-        <li>Rubricas de avaliação para monitoramento de competências.</li>
-      </ul>
-    </section>
-
-    <section id="diferenciais" class="card" style="margin-top:16px;">
-      <h2>Diferenciais do Arcabouço Pedagógico MAPEAR</h2>
-      <ul>
-        <li><strong>Flexibilidade:</strong> aplicável com ou sem tecnologia digital;</li>
-        <li><strong>Interdisciplinaridade:</strong> integração do PC com conteúdos curriculares e problemas reais;</li>
-        <li><strong>Protagonismo:</strong> incentiva autoria e autonomia de alunos e professores;</li>
-        <li><strong>Ciclos ativos</strong> de teoria, prática e reflexão;</li>
-        <li><strong>Formação contínua</strong> com trilhas gamificadas e microcertificações;</li>
-        <li><strong>Colaboração:</strong> socialização de práticas e fortalecimento de redes escolares.</li>
-      </ul>
-    </section>
-
-    <section id="steam" class="card" style="margin-top:16px;">
-      <h2>Integração com Metodologias Ativas e STEAM</h2>
-      <ul>
-        <li>Solução de problemas reais e contextualizados;</li>
-        <li>Aprendizagem interdisciplinar, conectando Ciências, Tecnologia, Engenharia, Artes e Matemática;</li>
-        <li>Desenvolvimento de habilidades cognitivas e socioemocionais;</li>
-        <li>Engajamento ativo e construção colaborativa do conhecimento.</li>
-      </ul>
-    </section>
-
-    <section id="resultados" class="card" style="margin-top:16px;">
-      <h2>Resultados Esperados</h2>
-      <ol>
-        <li><strong>Aprendizagem dos Estudantes:</strong> Engajamento, pensamento crítico, criatividade e competências em PC.</li>
-        <li><strong>Competências Docentes:</strong> Habilidade de integrar PC e RE em práticas pedagógicas alinhadas à BNCC.</li>
-        <li><strong>Repertório Pedagógico:</strong> Diversificação de estratégias de ensino com metodologias ativas, gamificação e recursos tecnológicos.</li>
-        <li><strong>Comunidade de Prática:</strong> Criação de redes colaborativas de alunos e professores que compartilham experiências e aprimoram continuamente a metodologia.</li>
-      </ol>
-    </section>
-
-    <section id="finais" class="card" style="margin-top:16px;">
-      <h2>Considerações Finais</h2>
-      <p>
-        O Arcabouço Pedagógico MAPEAR constitui uma abordagem inovadora que conecta teoria, prática, reflexão e tecnologia, favorecendo o desenvolvimento de competências de PC, habilidades socioemocionais e aprendizagem significativa. Sua flexibilidade, interdisciplinaridade e foco em protagonismo tornam-na adequada para contextos diversos, desde escolas básicas até programas de formação docente.
-      </p>
-      <p>
-        O ensino com o Arcabouço Pedagógico MAPEAR permite aos alunos e professores explorar o Pensamento Computacional de forma ativa e reflexiva, promovendo a construção de conhecimento contextualizado, colaborativo e interdisciplinar, essencial para a educação do século XXI.
-      </p>
-    </section>
-
-    <section id="curso" class="card" style="margin-top:16px;">
-      <h2>Curso de Formação MAPEAR</h2>
-      <p class="muted">Abra o curso em uma nova aba do navegador.</p>
-      <a class="button cta secondary" href="cursoMapear.html" target="_blank" rel="noopener">Abrir Curso MAPEAR em nova aba</a>
-    </section>
-
-    <section id="jogos" class="card" style="margin-top:16px;">
-      <h2>Jogos MAPEAR</h2>
-      <p class="muted">Abra os jogos em uma nova aba do navegador.</p>
-      <a class="button cta primary" href="mapear.html#/" target="_blank" rel="noopener">Abrir Jogos MAPEAR em nova aba</a>
     </section>
   </main>
 

--- a/index.html
+++ b/index.html
@@ -50,6 +50,10 @@
       <div class="figure">
         <img alt="Logo da Metodologia MAPEAR" src="https://carolsoko.github.io/mapear/MAPEAR.png">
       </div>
+      <div class="hero-actions">
+        <a class="button cta secondary" href="cursoMapear.html" target="_blank" rel="noopener">Abrir Curso MAPEAR</a>
+        <a class="button cta primary" href="mapear.html#/" target="_blank" rel="noopener">Abrir Jogos MAPEAR</a>
+      </div>
     </section>
 
     <section id="fases" class="card" style="margin-top:16px;">

--- a/styles.css
+++ b/styles.css
@@ -94,12 +94,17 @@ section, .card { scroll-margin-top: var(--hero-offset); }
 .hero-actions {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 12px;
-  margin-top: 12px;
+  gap: 16px;
+  margin-top: 16px;
 }
 .hero-actions .button.cta {
   width: 100%;
   justify-content: center;
+  padding: 18px 20px;
+  font-size: 18px;
+  line-height: 1.2;
+  border-radius: 16px;
+  box-shadow: 0 14px 36px rgba(0,0,0,0.45);
 }
 @media (max-width: 700px) {
   .hero-actions { grid-template-columns: 1fr; }
@@ -142,13 +147,13 @@ p { color: var(--text); line-height: 1.6; }
 
 /* Botões de destaque (CTA) para Curso e Jogos */
 .button.cta {
-  font-weight: 700;
-  letter-spacing: 0.2px;
-  padding: 12px 16px;
-  border-radius: 12px;
+  font-weight: 800;
+  letter-spacing: 0.3px;
+  padding: 16px 18px;
+  border-radius: 14px;
   border: 0;
   color: #ffffff;
-  box-shadow: 0 10px 24px rgba(0,0,0,0.35);
+  box-shadow: 0 12px 30px rgba(0,0,0,0.4);
   transition: transform 0.15s ease, box-shadow 0.2s ease, filter 0.2s ease;
 }
 .button.cta:hover { transform: translateY(-1px); filter: brightness(1.06); }

--- a/styles.css
+++ b/styles.css
@@ -91,6 +91,20 @@ section, .card { scroll-margin-top: var(--hero-offset); }
   padding: 24px 16px 80px;
 }
 
+.hero-actions {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+  margin-top: 12px;
+}
+.hero-actions .button.cta {
+  width: 100%;
+  justify-content: center;
+}
+@media (max-width: 700px) {
+  .hero-actions { grid-template-columns: 1fr; }
+}
+
 .card {
   background: linear-gradient(180deg, rgba(16,24,39,0.8), rgba(16,24,39,0.6));
   border: 1px solid rgba(148,163,184,0.15);

--- a/styles.css
+++ b/styles.css
@@ -33,13 +33,13 @@ section, .card { scroll-margin-top: var(--hero-offset); }
   justify-content: space-between;
   gap: 12px;
   padding: 16px 20px;
-  background: linear-gradient(135deg, rgba(124,156,255,.14), rgba(34,197,94,.10));
+  background: #111827;
   position: sticky;
   top: 0;
   left: 0;
   right: 0;
   z-index: 9999;
-  backdrop-filter: blur(6px);
+  backdrop-filter: none;
   border-bottom: 1px solid rgba(255,255,255,.08);
   box-shadow: 0 12px 30px rgba(0,0,0,0.25);
 }


### PR DESCRIPTION
Add "Abrir Curso" and "Abrir Jogos" buttons below the MAPEAR logo to be side-by-side and span the page width.

---
<a href="https://cursor.com/background-agent?bcId=bc-d2ca2a06-75fd-4143-84e4-2660914af98e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d2ca2a06-75fd-4143-84e4-2660914af98e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

