### PR TITLE
Organize and fix navigation menus across game and course pages

### DIFF
--- a/cursoMapear.html
+++ b/cursoMapear.html
@@ -6,6 +6,7 @@
   <title>Curso de Formação MAPEAR</title>
   <meta name="description" content="Curso de Formação MAPEAR: Fundamentos de Pensamento Computacional, ferramentas digitais e atividades desplugadas, planejamento com mediação ativa e reflexão estruturada, avaliação de competências e compartilhamento de práticas." />
   <link rel="icon" type="image/png" href="/MAPEARFavicon.png">
+  <link rel="stylesheet" href="./styles.css">
   <style>
     :root {
       --bg: #0b1020;
@@ -37,20 +38,8 @@
     }
     a { color: var(--brand); text-decoration: none }
     a:hover { text-decoration: underline }
-    .wrap { max-width: 1100px; margin: 0 auto; padding: calc(28px + var(--hero-offset)) 28px 28px }
-    header.hero {
-      border-radius: var(--radius-xl);
-      background: #111827;
-      padding: 36px;
-      box-shadow: var(--shadow-2);
-      position: fixed;
-      top: 0;
-      left: 0;
-      right: 0;
-      z-index: 9999;
-      overflow: hidden;
-      isolation: isolate;
-    }
+    .wrap { max-width: 1100px; margin: 0 auto; padding: 28px 28px 28px }
+    header.hero { display: none }
     .badge { display: inline-block; padding: 6px 12px; border-radius: 999px; background: rgba(124,156,255,.18); color: #dbe5ff; font-weight: 600; letter-spacing: .3px }
     h1 { font-size: clamp(28px, 4vw, 44px); margin: 10px 0 8px }
     .sub { color: var(--muted); max-width: 70ch }
@@ -136,28 +125,35 @@
   </style>
 </head>
 <body>
-  <div class="wrap">
-    <header class="hero" id="topo" aria-labelledby="titulo">
-      <nav class="quick-nav" role="navigation" aria-label="Navegação rápida">
-        <a class="btn ghost" href="#topo">Topo</a>
-        <a class="btn ghost" href="index.html#intro">Início</a>
-        <a class="btn ghost" href="conteudo.html">Conteúdo</a>
-        <a class="btn ghost" href="mapear.html#/">Jogos</a>
-        <a class="btn ghost" href="#programa">Programa</a>
-        <a class="btn ghost" href="#mod1">Módulo 1</a>
-        <a class="btn ghost" href="#mod2">Módulo 2</a>
-        <a class="btn ghost" href="#mod3">Módulo 3</a>
-        <a class="btn ghost" href="#mod4">Módulo 4</a>
-        <a class="btn ghost" href="#mod5">Módulo 5</a>
-        <a class="btn ghost" href="#avaliacao">Matriz</a>
-        <a class="btn ghost" href="#cronograma">Cronograma</a>
-        <a class="btn ghost" href="#recursos">Recursos</a>
-        <a class="btn ghost" href="#baralho">Baralho</a>
-        <a class="btn ghost" href="#faq">FAQ</a>
-      </nav>
-    </header>
+  <header class="app-header">
+    <div class="brand">
+      <span class="brand-title">Arcabouço Pedagógico MAPEAR</span>
+      <span class="brand-subtitle">Pensamento Computacional com Consciência</span>
+    </div>
+    <nav class="main-nav">
+      <a class="btn ghost" href="./FichasRubricasMAPEAR.pdf" download>Baixar Rubricas (PDF)</a>
+      <a class="btn ghost" href="index.html#intro">Início</a>
+      <a class="btn ghost" href="conteudo.html">Conteúdo</a>
+      <a class="btn ghost" href="cursoMapear.html">Curso</a>
+      <a class="btn ghost" href="mapear.html#/">Jogos</a>
+    </nav>
+  </header>
+  <nav class="sub-nav" aria-label="Navegação do curso">
+    <a href="#topo">Topo</a>
+    <a href="#programa">Programa</a>
+    <a href="#mod1">Módulo 1</a>
+    <a href="#mod2">Módulo 2</a>
+    <a href="#mod3">Módulo 3</a>
+    <a href="#mod4">Módulo 4</a>
+    <a href="#mod5">Módulo 5</a>
+    <a href="#avaliacao">Matriz</a>
+    <a href="#cronograma">Cronograma</a>
+    <a href="#recursos">Recursos</a>
+    <a href="#baralho">Baralho</a>
+    <a href="#faq">FAQ</a>
+  </nav>
 
-    <div class="divider"></div>
+  <div class="wrap">
 
     <section class="card" aria-labelledby="titulo">
       <span class="badge">Formação Docente • MAPEAR</span>

--- a/mapear.html
+++ b/mapear.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Jogos MAPEAR — Pensamento Computacional</title>
   <link rel="icon" type="image/png" href="./MAPEARFavicon.png">
+  <link rel="stylesheet" href="./styles.css">
   <style>
 :root {
   --bg: #0f172a;
@@ -32,14 +33,10 @@ body {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  justify-content: flex-start;
+  justify-content: space-between;
   gap: 12px;
   padding: 16px 20px;
-  background: linear-gradient(180deg, rgba(17,24,39,0.9), rgba(17,24,39,0.6));
-  position: sticky;
-  top: 0;
-  backdrop-filter: blur(10px);
-  z-index: 10;
+  background: #111827;
 }
 
 .brand { display: flex; align-items: center; gap: 10px; }
@@ -134,24 +131,28 @@ label { display: block; font-size: 13px; color: var(--muted); margin: 6px 0; }
 <body>
   <header class="app-header">
     <div class="brand">
-      <img class="brand-icon" alt="MAPEAR" src="./MAPEARFavicon.png">
-      <div class="brand-text">
-        <span class="brand-title">Jogos MAPEAR</span>
-        <span class="brand-subtitle">Pensamento Computacional</span>
-      </div>
+      <span class="brand-title">Arcabouço Pedagógico MAPEAR</span>
+      <span class="brand-subtitle">Pensamento Computacional com Consciência</span>
     </div>
     <nav class="main-nav">
-      <a href="#/" data-route>Início</a>
-      <a href="#/padroes" data-route>Detective de Padrões</a>
-      <a href="#/abstracao" data-route>Abstração</a>
-      <a href="#/decomposicao" data-route>Decomposição</a>
-      <a href="#/algoritmo" data-route>Algoritmos</a>
-      <a href="#/generalizacao" data-route>Generalize+</a>
-      <a href="#/robotica" data-route>Robótica</a>
-      <a href="#/relatorios" data-route>Relatórios</a>
-      <a href="#/ajustes" data-route>Ajustes</a>
+      <a class="btn ghost" href="./FichasRubricasMAPEAR.pdf" download>Baixar Rubricas (PDF)</a>
+      <a class="btn ghost" href="index.html#intro">Início</a>
+      <a class="btn ghost" href="conteudo.html">Conteúdo</a>
+      <a class="btn ghost" href="cursoMapear.html">Curso</a>
+      <a class="btn ghost" href="mapear.html#/">Jogos</a>
     </nav>
   </header>
+  <nav class="sub-nav" aria-label="Navegação dos jogos">
+    <a href="#/" data-route>Início</a>
+    <a href="#/padroes" data-route>Detective de Padrões</a>
+    <a href="#/abstracao" data-route>Abstração</a>
+    <a href="#/decomposicao" data-route>Decomposição</a>
+    <a href="#/algoritmo" data-route>Algoritmos</a>
+    <a href="#/generalizacao" data-route>Generalize+</a>
+    <a href="#/robotica" data-route>Robótica</a>
+    <a href="#/relatorios" data-route>Relatórios</a>
+    <a href="#/ajustes" data-route>Ajustes</a>
+  </nav>
 
   <main id="app" class="app-container" aria-live="polite"></main>
 
@@ -336,7 +337,7 @@ label { display: block; font-size: 13px; color: var(--muted); margin: 6px 0; }
   <script>
   (function(){
     const appEl = document.getElementById('app');
-    const navLinks = Array.from(document.querySelectorAll('nav.main-nav a[data-route]'));
+    const navLinks = Array.from(document.querySelectorAll('nav.sub-nav a[data-route]'));
 
     function setActiveNav(hash) {
       navLinks.forEach(a => {

--- a/styles.css
+++ b/styles.css
@@ -21,6 +21,7 @@ body {
               radial-gradient(800px 600px at 10% 110%, rgba(34,197,94,.12), transparent 60%),
               var(--bg);
   color: var(--text);
+  padding-top: 124px;
 }
 
 html { scroll-behavior: smooth; }
@@ -34,7 +35,7 @@ section, .card { scroll-margin-top: var(--hero-offset); }
   gap: 12px;
   padding: 16px 20px;
   background: #111827;
-  position: sticky;
+  position: fixed;
   top: 0;
   left: 0;
   right: 0;
@@ -60,6 +61,33 @@ section, .card { scroll-margin-top: var(--hero-offset); }
 }
 .main-nav a:not(.btn):hover { background: rgba(96,165,250,0.1); border-color: rgba(96,165,250,0.3); }
 .main-nav a.active:not(.btn) { background: rgba(34,197,94,0.12); border-color: rgba(34,197,94,0.35); }
+
+/* Submenu fixo logo abaixo do header principal */
+.sub-nav {
+  position: fixed;
+  top: 68px;
+  left: 0;
+  right: 0;
+  z-index: 9998;
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 10px;
+  padding: 10px 20px;
+  background: #0f162b;
+  border-bottom: 1px solid rgba(255,255,255,.08);
+  box-shadow: 0 8px 20px rgba(0,0,0,0.25);
+  overflow-x: auto;
+}
+.sub-nav a {
+  text-decoration: none;
+  color: var(--text);
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+.sub-nav a:hover { background: rgba(96,165,250,0.1); border-color: rgba(96,165,250,0.3); }
+.sub-nav a.active { background: rgba(34,197,94,0.12); border-color: rgba(34,197,94,0.35); }
 
 /* Botões no estilo do curso MAPEAR */
 .btn {


### PR DESCRIPTION
Unify the main header and add fixed page-specific submenus to "Jogos MAPEAR" and "Curso MAPEAR" pages.

This PR implements the user's request to standardize the main navigation across `index.html`, `cursoMapear.html`, and `mapear.html`, ensuring the "Arcabouço Pedagógico MAPEAR" brand is consistent. It also introduces page-specific submenus for "Jogos MAPEAR" and "Curso MAPEAR" and makes both the main header and submenus fixed at the top of the viewport.

---
<a href="https://cursor.com/background-agent?bcId=bc-288dc852-3fa3-4f22-a4aa-7d1b6e6d37af">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-288dc852-3fa3-4f22-a4aa-7d1b6e6d37af">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

