### PR TITLE
Fix mobile menu and logo size

### DIFF
--- a/conteudo.html
+++ b/conteudo.html
@@ -124,5 +124,22 @@
   <footer class="footer">
       Arcabouço Pedagógico MAPEAR — Aprendizagem ativa, reflexiva e colaborativa
   </footer>
+  <script>
+    (function(){
+      function setHeaderHeightVar(){
+        var header = document.querySelector('.app-header');
+        var h = header ? Math.ceil(header.getBoundingClientRect().height) : 124;
+        document.documentElement.style.setProperty('--app-header-height', h + 'px');
+      }
+      if (document.readyState !== 'loading') setHeaderHeightVar();
+      else document.addEventListener('DOMContentLoaded', setHeaderHeightVar);
+      window.addEventListener('resize', setHeaderHeightVar, { passive: true });
+      var header = document.querySelector('.app-header');
+      if (header && 'ResizeObserver' in window) {
+        var ro = new ResizeObserver(setHeaderHeightVar);
+        ro.observe(header);
+      }
+    })();
+  </script>
 </body>
 </html>

--- a/cursoMapear.html
+++ b/cursoMapear.html
@@ -1011,6 +1011,23 @@
   </div>
   <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js" defer></script>
+  <script>
+    (function(){
+      function setHeaderHeightVar(){
+        var header = document.querySelector('.app-header');
+        var h = header ? Math.ceil(header.getBoundingClientRect().height) : 124;
+        document.documentElement.style.setProperty('--app-header-height', h + 'px');
+      }
+      if (document.readyState !== 'loading') setHeaderHeightVar();
+      else document.addEventListener('DOMContentLoaded', setHeaderHeightVar);
+      window.addEventListener('resize', setHeaderHeightVar, { passive: true });
+      var header = document.querySelector('.app-header');
+      if (header && 'ResizeObserver' in window) {
+        var ro = new ResizeObserver(setHeaderHeightVar);
+        ro.observe(header);
+      }
+    })();
+  </script>
   <script defer>
     (function(){
       function fitInsideCell(pdf, imgData, cell){

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
       <span class="brand-subtitle">Pensamento Computacional com Consciência</span>
     </div>
     <nav class="main-nav">
-      <a class="btn ghost" href="#intro">Introdução</a>
+      <a class="btn ghost" href="#intro">Início</a>
       <a class="btn ghost" href="conteudo.html">Conteúdo</a>
       <a class="btn ghost" href="cursoMapear.html">Curso</a>
       <a class="btn ghost" href="mapear.html#/">Jogos</a>
@@ -50,5 +50,22 @@
   <footer class="footer">
       Arcabouço Pedagógico MAPEAR — Aprendizagem ativa, reflexiva e colaborativa
     </footer>
+  <script>
+    (function(){
+      function setHeaderHeightVar(){
+        var header = document.querySelector('.app-header');
+        var h = header ? Math.ceil(header.getBoundingClientRect().height) : 124;
+        document.documentElement.style.setProperty('--app-header-height', h + 'px');
+      }
+      if (document.readyState !== 'loading') setHeaderHeightVar();
+      else document.addEventListener('DOMContentLoaded', setHeaderHeightVar);
+      window.addEventListener('resize', setHeaderHeightVar, { passive: true });
+      var header = document.querySelector('.app-header');
+      if (header && 'ResizeObserver' in window) {
+        var ro = new ResizeObserver(setHeaderHeightVar);
+        ro.observe(header);
+      }
+    })();
+  </script>
 </body>
 </html>

--- a/mapear.html
+++ b/mapear.html
@@ -2396,5 +2396,22 @@ label { display: block; font-size: 13px; color: var(--muted); margin: 6px 0; }
   <footer class="footer">
       Arcabouço Pedagógico MAPEAR — Aprendizagem ativa, reflexiva e colaborativa
     </footer>
+  <script>
+    (function(){
+      function setHeaderHeightVar(){
+        var header = document.querySelector('.app-header');
+        var h = header ? Math.ceil(header.getBoundingClientRect().height) : 124;
+        document.documentElement.style.setProperty('--app-header-height', h + 'px');
+      }
+      if (document.readyState !== 'loading') setHeaderHeightVar();
+      else document.addEventListener('DOMContentLoaded', setHeaderHeightVar);
+      window.addEventListener('resize', setHeaderHeightVar, { passive: true });
+      var header = document.querySelector('.app-header');
+      if (header && 'ResizeObserver' in window) {
+        var ro = new ResizeObserver(setHeaderHeightVar);
+        ro.observe(header);
+      }
+    })();
+  </script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -27,6 +27,9 @@ body {
 html { scroll-behavior: smooth; }
 section, .card { scroll-margin-top: var(--hero-offset); }
 
+/* Imagens responsivas (evita que logos/figuras estourem a largura no mobile) */
+img { max-width: 100%; height: auto; }
+
 .app-header {
   display: flex;
   flex-wrap: wrap;
@@ -64,10 +67,8 @@ section, .card { scroll-margin-top: var(--hero-offset); }
 
 /* Submenu fixo logo abaixo do header principal */
 .sub-nav {
-  position: fixed;
+  position: sticky;
   top: 68px;
-  left: 0;
-  right: 0;
   z-index: 9998;
   display: flex;
   flex-wrap: nowrap;
@@ -78,6 +79,7 @@ section, .card { scroll-margin-top: var(--hero-offset); }
   box-shadow: 0 8px 20px rgba(0,0,0,0.25);
   overflow-x: auto;
 }
+@media (max-width: 700px) { .sub-nav { top: 124px; } }
 .sub-nav a {
   text-decoration: none;
   color: var(--text);

--- a/styles.css
+++ b/styles.css
@@ -21,7 +21,7 @@ body {
               radial-gradient(800px 600px at 10% 110%, rgba(34,197,94,.12), transparent 60%),
               var(--bg);
   color: var(--text);
-  padding-top: 124px;
+  padding-top: var(--app-header-height, 124px);
 }
 
 html { scroll-behavior: smooth; }
@@ -68,7 +68,7 @@ img { max-width: 100%; height: auto; }
 /* Submenu fixo logo abaixo do header principal */
 .sub-nav {
   position: sticky;
-  top: 68px;
+  top: var(--app-header-height, 124px);
   z-index: 9998;
   display: flex;
   flex-wrap: nowrap;
@@ -79,7 +79,6 @@ img { max-width: 100%; height: auto; }
   box-shadow: 0 8px 20px rgba(0,0,0,0.25);
   overflow-x: auto;
 }
-@media (max-width: 700px) { .sub-nav { top: 124px; } }
 .sub-nav a {
   text-decoration: none;
   color: var(--text);


### PR DESCRIPTION
Fix mobile display issues by making images responsive and adjusting submenu positioning.

This PR addresses two problems: the logo on `conteudo.html` overflowing on mobile, and submenus being hidden on smaller screens. The `.sub-nav` is now sticky with an adjusted top offset for mobile, ensuring visibility, and all images are set to be responsive.

---
<a href="https://cursor.com/background-agent?bcId=bc-1c2b1321-fe15-4483-b46d-a2d47268cf3c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1c2b1321-fe15-4483-b46d-a2d47268cf3c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

