### PR TITLE
Fix course submenu on mobile

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -10,6 +10,7 @@
   --ok: #10b981;
   --card: #0b1220;
   --hero-offset: 140px;
+  --header-offset: 124px;
 }
 
 * { box-sizing: border-box; }
@@ -21,7 +22,7 @@ body {
               radial-gradient(800px 600px at 10% 110%, rgba(34,197,94,.12), transparent 60%),
               var(--bg);
   color: var(--text);
-  padding-top: 124px;
+  padding-top: var(--header-offset);
 }
 
 html { scroll-behavior: smooth; }
@@ -79,7 +80,10 @@ img { max-width: 100%; height: auto; }
   box-shadow: 0 8px 20px rgba(0,0,0,0.25);
   overflow-x: auto;
 }
-@media (max-width: 700px) { .sub-nav { top: 124px; } }
+@media (max-width: 700px) {
+  :root { --header-offset: 160px; }
+  .sub-nav { top: var(--header-offset); }
+}
 .sub-nav a {
   text-decoration: none;
   color: var(--text);


### PR DESCRIPTION
Fix 'curso mapear' submenu not appearing on mobile by adjusting its sticky offset.

On mobile, the fixed header was taller, causing the `.sub-nav` to be hidden underneath it. This PR introduces a `--header-offset` CSS variable and increases its value for mobile screens, ensuring the submenu is correctly positioned below the header.

---
<a href="https://cursor.com/background-agent?bcId=bc-0dfdd68e-6558-4f0a-99d3-074fb85eda07">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0dfdd68e-6558-4f0a-99d3-074fb85eda07">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

