### PR TITLE
Make submenus non-fixed on mobile

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -103,7 +103,7 @@ img { max-width: 100%; height: auto; }
 }
 @media (max-width: 700px) {
   :root { --header-offset: 160px; }
-  .sub-nav { top: var(--header-offset); }
+  .sub-nav { position: static; top: auto; }
 }
 
 /* Compactar botões do menu principal para reduzir a altura do cabeçalho */


### PR DESCRIPTION
Make submenus on `mapear.html` and `cursoMapear.html` scroll with content on mobile by unfixing their position.

---
<a href="https://cursor.com/background-agent?bcId=bc-0b35cf11-7e6e-4606-824c-1688d44f1c7d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0b35cf11-7e6e-4606-824c-1688d44f1c7d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

